### PR TITLE
Rewrite custom prefixes module

### DIFF
--- a/bot/cogs/config.py
+++ b/bot/cogs/config.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
     from bot.kumiko import Kumiko
 
+### Converters
+
 
 class PrefixConverter(commands.Converter):
     async def convert(self, ctx: GuildContext, argument: str):

--- a/bot/cogs/config.py
+++ b/bot/cogs/config.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from libs.utils import Embed
+from libs.utils.checks import is_manager
+from libs.utils.prefix import get_prefix
+from typing_extensions import Annotated
+
+if TYPE_CHECKING:
+    from libs.utils.context import GuildContext
+
+    from bot.kumiko import Kumiko
+
+
+class PrefixConverter(commands.Converter):
+    async def convert(self, ctx: GuildContext, argument: str):
+        user_id = ctx.bot.user.id  # type: ignore # Already logged in by this time
+        if argument.startswith((f"<@{user_id}>", f"<@!{user_id}>", ">")):
+            raise commands.BadArgument("That is a reserved prefix already in use.")
+        if len(argument) > 100:
+            raise commands.BadArgument("That prefix is too long.")
+        return argument
+
+
+class Config(commands.Cog):
+    """Configuration layer for Kumiko"""
+
+    def __init__(self, bot: Kumiko):
+        self.bot = bot
+        self.pool = self.bot.pool
+
+    @property
+    def display_emoji(self) -> discord.PartialEmoji:
+        return discord.PartialEmoji(name="\U0001f6e0")
+
+    ### Prefix utilities
+
+    def clean_prefixes(self, prefixes: Union[str, list[str]]) -> str:
+        if isinstance(prefixes, str):
+            return f"`{prefixes}`"
+
+        return ", ".join(f"`{prefix}`" for prefix in prefixes[2:])
+
+    @is_manager()
+    @commands.guild_only()
+    @commands.hybrid_group(name="config")
+    async def config(self, ctx: GuildContext) -> None:
+        """Modifiable configuration layer for Kumiko"""
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help(ctx.command)
+
+    @is_manager()
+    @commands.guild_only()
+    @config.group(name="prefix", fallback="info")
+    async def prefix(self, ctx: GuildContext) -> None:
+        """Shows and manages custom prefixes for the guild
+
+        Passing in no subcommands will effectively show the currently set prefixes.
+        """
+        prefixes = await get_prefix(self.bot, ctx.message)
+        embed = Embed()
+        embed.add_field(
+            name="Prefixes", value=self.clean_prefixes(prefixes), inline=False
+        )
+        embed.add_field(name="Total", value=len(prefixes) - 2, inline=False)
+        embed.set_author(name=ctx.guild.name, icon_url=ctx.guild.icon.url)  # type: ignore
+        await ctx.send(embed=embed)
+
+    @is_manager()
+    @commands.guild_only()
+    @prefix.command(name="add")
+    @app_commands.describe(prefix="The new prefix to add")
+    async def prefix_add(
+        self, ctx: GuildContext, prefix: Annotated[str, PrefixConverter]
+    ) -> None:
+        """Adds an custom prefix"""
+        prefixes = await get_prefix(self.bot, ctx.message)
+
+        # 2 are the mention prefixes, which are always prepended on the list of prefixes
+        if isinstance(prefixes, list) and len(prefixes) > 13:
+            await ctx.send(
+                "You can not have more than 10 custom prefixes for your server"
+            )
+            return
+        elif prefix in prefixes:
+            await ctx.send("The prefix you want to set already exists")
+            return
+
+        query = """
+            INSERT INTO guild_prefix (id, prefix) VALUES ($2, ARRAY[$1])
+            ON CONFLICT (id) DO UPDATE
+            SET prefix = ARRAY_APPEND(guild_prefix.prefix, $1) WHERE guild_prefix.id = $2;
+        """
+        await self.pool.execute(query, prefix, ctx.guild.id)
+        get_prefix.cache_invalidate(self.bot, ctx.message)
+        await ctx.send(f"Added prefix: `{prefix}`")
+
+    @is_manager()
+    @commands.guild_only()
+    @prefix.command(name="edit")
+    @app_commands.describe(
+        old="The prefix to edit", new="A new prefix to replace the old"
+    )
+    @app_commands.rename(old="old_prefix", new="new_prefix")
+    async def prefix_edit(
+        self,
+        ctx: GuildContext,
+        old: Annotated[str, PrefixConverter],
+        new: Annotated[str, PrefixConverter],
+    ) -> None:
+        """Edits and replaces a prefix"""
+        query = """
+            UPDATE guild_prefix
+            SET prefix = ARRAY_REPLACE(prefix, $1, $2)
+            WHERE id = $3;
+        """
+        prefixes = await get_prefix(self.bot, ctx.message)
+
+        guild_id = ctx.guild.id
+        if old in prefixes:
+            await self.pool.execute(query, old, new, guild_id)
+            get_prefix.cache_invalidate(self.bot, ctx.message)
+            await ctx.send(f"Prefix updated to from `{old}` to `{new}`")
+        else:
+            await ctx.send("The prefix is not in the list of prefixes for your server")
+
+    @is_manager()
+    @commands.guild_only()
+    @prefix.command(name="delete")
+    @app_commands.describe(prefix="The prefix to delete")
+    async def prefix_delete(
+        self, ctx: GuildContext, prefix: Annotated[str, PrefixConverter]
+    ) -> None:
+        """Deletes a set prefix"""
+        query = "DELETE FROM guild_prefix WHERE id = $1;"
+        msg = f"Do you want to delete the following prefix: {prefix}"
+        confirm = await ctx.prompt(msg, timeout=120.0, delete_after=True)
+        if confirm:
+            await self.pool.execute(query, prefix, ctx.guild.id)
+            get_prefix.cache_invalidate(self.bot, ctx.message)
+            await ctx.send(f"The prefix `{prefix}` has been successfully deleted")
+        elif confirm is None:
+            await ctx.send("Confirmation timed out. Cancelled deletion...")
+        else:
+            await ctx.send("Confirmation cancelled. Please try again")
+
+
+async def setup(bot: Kumiko) -> None:
+    await bot.add_cog(Config(bot))

--- a/bot/libs/utils/checks.py
+++ b/bot/libs/utils/checks.py
@@ -58,7 +58,7 @@ def check_permissions(**perms: bool) -> Callable[[T], T]:
         ):
             return False
         guild_perms = await check_guild_permissions(ctx, perms)
-        can_run = ctx.me.top_role > ctx.author.top_role
+        can_run = ctx.me.top_role < ctx.author.top_role
         return guild_perms and can_run
 
     def decorator(func: T) -> T:

--- a/bot/libs/utils/checks.py
+++ b/bot/libs/utils/checks.py
@@ -58,7 +58,7 @@ def check_permissions(**perms: bool) -> Callable[[T], T]:
         ):
             return False
         guild_perms = await check_guild_permissions(ctx, perms)
-        can_run = ctx.me.top_role < ctx.author.top_role
+        can_run = ctx.me.top_role > ctx.author.top_role
         return guild_perms and can_run
 
     def decorator(func: T) -> T:

--- a/bot/libs/utils/prefix.py
+++ b/bot/libs/utils/prefix.py
@@ -36,7 +36,7 @@ async def get_prefix(bot: Kumiko, message: discord.Message) -> Union[str, list[s
 
     query = """
     SELECT prefix
-    FROM guild_config
+    FROM guild_prefix
     WHERE id = $1;
     """
     prefixes = await bot.pool.fetchval(query, message.guild.id)

--- a/bot/migrations/V1__initial_migration.sql
+++ b/bot/migrations/V1__initial_migration.sql
@@ -3,7 +3,7 @@
 -- Creation Date: 2024-04-28 00:16:33.339328 UTC
 -- Reason: initial_migration
 
-CREATE TABLE IF NOT EXISTS guild_config (
+CREATE TABLE IF NOT EXISTS guild_prefix (
     id BIGINT PRIMARY KEY,
     prefix TEXT[]
 );

--- a/changelog.d/565.misc.md
+++ b/changelog.d/565.misc.md
@@ -1,0 +1,1 @@
+Rewrite custom prefixes module


### PR DESCRIPTION
# Summary

Rewrites custom prefix module, thus making it more secure. The major redesign is the prefixes are now stored into a different table, thus making it much more decoupled. This makes it where when the `on_guild_join` event is called, we don't need to make a guild config entry, which makes it more vulnerable.

## Types of changes

What types of changes does your code introduce to Kumiko?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [x] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
