### PR TITLE
Implement AniList module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/bot/cogs/anilist.py
+++ b/bot/cogs/anilist.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Callable, Literal, Optional
+
+import discord
+import msgspec
+from discord.ext import commands
+
+if TYPE_CHECKING:
+    from libs.utils.context import GuildContext
+
+    from bot.kumiko import Kumiko
+
+import aiohttp
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+
+### Command Flags
+
+
+class SearchFlags(commands.FlagConverter):
+    title: Annotated[Optional[str], commands.clean_content] = commands.flag(
+        name="title", description="The title to search against", default=None
+    )
+
+    # Sorting
+
+    sort: Optional[
+        Literal[
+            "ROLE",
+            "ROLE_DESC",
+            "SEARCH_MATCH",
+            "FAVOURITES",
+            "FAVOURITES_DESC",
+            "RELEVANCE",
+        ]
+    ] = commands.flag(
+        name="character-sort",
+        description="How character information is sorted",
+        default="RELEVANCE",
+    )
+
+    # Tags
+
+    # This flag probably would work best with an autocomplete
+    # these also would work pretty well for autocompletes
+    tags: Optional[str] = commands.flag(
+        name="tags", description="Tags to specify", default=None
+    )
+    genre: Optional[
+        Literal[
+            "Action",
+            "Adventure",
+            "Comedy",
+            "Drama",
+            "Ecchi",
+            "Fantasy",
+            "Horror",
+            "Mahou Shoujo",
+            "Meecha",
+            "Music",
+            "Mystery",
+            "Psychological",
+            "Romance",
+            "Sci-Fi",
+            "Slice of Life",
+            "Sports",
+            "Supernatural",
+            "Thriller",
+        ]
+    ] = commands.flag(name="genre", description="Genres to select", default=None)
+
+    # Others
+    adult: Optional[bool] = commands.flag(
+        name="Whether to include adult related content", default=False
+    )
+
+
+### Transport Overrides
+
+
+# This is necessary in order to force GQL to see an aiohttp.ClientSession instance
+class AIOHTTPTransportExistingSession(AIOHTTPTransport):
+    def __init__(
+        self, session: aiohttp.ClientSession, deserializer: Callable, *args, **kwargs
+    ):
+        super().__init__(json_deserialize=deserializer, *args, **kwargs)
+        self.session = session
+
+    async def connect(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class Anilist(commands.GroupCog):
+    """AniList related commands"""
+
+    BASE_URL = "https://graphql.anilist.co/"
+
+    def __init__(self, bot: Kumiko):
+        self.bot = bot
+
+        self._transport = AIOHTTPTransportExistingSession(
+            session=self.bot.session,
+            deserializer=msgspec.json.Decoder,
+            url=self.BASE_URL,
+        )
+        self.client = Client(transport=self._transport)
+
+    @property
+    def display_emoji(self) -> discord.PartialEmoji:
+        return discord.PartialEmoji.from_str("<:SillyMe:1311606523872411648>")
+
+    @commands.hybrid_command(name="search")
+    async def search(self, ctx: GuildContext, *, flags: SearchFlags) -> None:
+        await ctx.defer()
+        params = {
+            "search": flags.title,
+            "sort": flags.sort,
+            "tagIn": flags.tags,
+            "genreIn": flags.genre,
+            "isAdult": flags.adult,
+        }
+        query = gql(
+            """
+query ($search: String!, $sort: [CharacterSort], $tagIn: [String], $genreIn: [String], $isAdult: Boolean)  {
+  Page {
+    media (search: $search, tag_in: $tagIn, genre_in: $genreIn, isAdult: $isAdult) {
+      id
+      title {
+        native
+        romaji
+        english
+      }
+      description
+      chapters
+      volumes
+      rankings {
+        context
+        rank
+        year
+      }
+      format
+      status
+      startDate {
+        year
+        month
+        day
+      }
+      endDate {
+        year
+        month
+        day
+      }
+      seasonYear
+      season
+      averageScore
+      meanScore
+      popularity
+      favourites
+      studios {
+        nodes {
+          name
+          siteUrl
+        }
+      }
+      hashtag
+      genres
+      characters(sort: $sort) {
+        edges {
+          name
+          role
+          node {
+            siteUrl
+            image {
+              large
+            }
+          }
+        }
+      }
+      tags {
+        category
+        isGeneralSpoiler
+        isMediaSpoiler
+        name
+        rank
+      }
+      coverImage {
+        large
+      }
+    }
+  }
+}
+            """
+        )
+        async with self.client as session:
+            data = await session.execute(query, variable_values=params)
+            print(data["Page"])
+            await ctx.send("it works")
+
+
+async def setup(bot: Kumiko) -> None:
+    await bot.add_cog(Anilist(bot))

--- a/bot/cogs/anilist.py
+++ b/bot/cogs/anilist.py
@@ -125,74 +125,74 @@ class Anilist(commands.GroupCog):
         }
         query = gql(
             """
-query ($search: String!, $sort: [CharacterSort], $tagIn: [String], $genreIn: [String], $isAdult: Boolean)  {
-  Page {
-    media (search: $search, tag_in: $tagIn, genre_in: $genreIn, isAdult: $isAdult) {
-      id
-      title {
-        native
-        romaji
-        english
-      }
-      description
-      chapters
-      volumes
-      rankings {
-        context
-        rank
-        year
-      }
-      format
-      status
-      startDate {
-        year
-        month
-        day
-      }
-      endDate {
-        year
-        month
-        day
-      }
-      seasonYear
-      season
-      averageScore
-      meanScore
-      popularity
-      favourites
-      studios {
-        nodes {
-          name
-          siteUrl
-        }
-      }
-      hashtag
-      genres
-      characters(sort: $sort) {
-        edges {
-          name
-          role
-          node {
-            siteUrl
-            image {
-              large
-            }
-          }
-        }
-      }
-      tags {
-        category
-        isGeneralSpoiler
-        isMediaSpoiler
-        name
-        rank
-      }
-      coverImage {
-        large
-      }
-    }
-  }
-}
+                query ($search: String!, $sort: [CharacterSort], $tagIn: [String], $genreIn: [String], $isAdult: Boolean)  {
+                  Page {
+                    media (search: $search, tag_in: $tagIn, genre_in: $genreIn, isAdult: $isAdult) {
+                      id
+                      title {
+                        native
+                        romaji
+                        english
+                      }
+                      description
+                      chapters
+                      volumes
+                      rankings {
+                        context
+                        rank
+                        year
+                      }
+                      format
+                      status
+                      startDate {
+                        year
+                        month
+                        day
+                      }
+                      endDate {
+                        year
+                        month
+                        day
+                      }
+                      seasonYear
+                      season
+                      averageScore
+                      meanScore
+                      popularity
+                      favourites
+                      studios {
+                        nodes {
+                          name
+                          siteUrl
+                        }
+                      }
+                      hashtag
+                      genres
+                      characters(sort: $sort) {
+                        edges {
+                          name
+                          role
+                          node {
+                            siteUrl
+                            image {
+                              large
+                            }
+                          }
+                        }
+                      }
+                      tags {
+                        category
+                        isGeneralSpoiler
+                        isMediaSpoiler
+                        name
+                        rank
+                      }
+                      coverImage {
+                        large
+                      }
+                    }
+                  }
+                }
             """
         )
         async with self.client as session:

--- a/bot/cogs/anilist.py
+++ b/bot/cogs/anilist.py
@@ -115,6 +115,7 @@ class Anilist(commands.GroupCog):
 
     @commands.hybrid_command(name="search")
     async def search(self, ctx: GuildContext, *, flags: SearchFlags) -> None:
+        """Search for media and others on AniList"""
         await ctx.defer()
         params = {
             "search": flags.title,

--- a/bot/libs/utils/checks.py
+++ b/bot/libs/utils/checks.py
@@ -57,9 +57,7 @@ def check_permissions(**perms: bool) -> Callable[[T], T]:
             or ctx.guild is None
         ):
             return False
-        guild_perms = await check_guild_permissions(ctx, perms)
-        can_run = ctx.me.top_role > ctx.author.top_role
-        return guild_perms and can_run
+        return await check_guild_permissions(ctx, perms)
 
     def decorator(func: T) -> T:
         func.extras["permissions"] = perms

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[speed,voice]>=2.4.0,<3
+discord.py[speed,voice] @ git+https://github.com/Rapptz/discord.py@e1b6310ef387481a654a1085653a33aa1b17e034
 audioop-lts>=0.2.1,<1 ; python_version>='3.13'
 uvloop>=0.21.0,<1 ; sys_platform != "win32"
 winloop>=0.1.6,<1 ; sys_platform == "win32"
@@ -16,3 +16,4 @@ jishaku>=2.6.0,<3
 watchfiles>=1.0.0,<2
 click>=8.1.7,<9
 typing-extensions>=4.12.0,<5
+gql>=3.6.0b2,<4


### PR DESCRIPTION
# Summary

Aims to close (#556) by fully implementing AniList support. Previously, only searching for anime/manga was allowed, but now, this time there is full support for this module.
The `/search anime` and `/search manga` commands have been merged into one command, `/anilist search` with dedicated flags for searching, sorting, and many more. In addition, characters are now displayed within search queries on their own pages, and others such as studios, users, and others will be added soon.

## To-Do Checklist

As of now, this is the current list of tasks that needs to be done in order for this PR to be complete:

- [ ] Searching for characters
- [ ] Charcter inclusion within `/anilist search`
- [ ] Dedicated searching for studios
- [ ] Dedicated searching for staff and users
- [ ] Reviews (<2000 characters) within `/anilist search` commands

## Types of changes

What types of changes does your code introduce to Kumiko?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [ ] All workflows pass with my new changes
- [ ] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
