### PR TITLE
Use custom `no767/get-releasenote` action instead of `changelog.md` for obtaining release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
         name: artifact
         path: releases
 
+    - name: Generate release notes
+      uses: no767/get-releasenote@0.1.0
+      with:
+        name: Kumiko
+        changes_file: changelog.md
+        output_file: output.md
+        version_file: bot/cogs/__init__.py
+
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.67.0
       id: tag_version
@@ -56,7 +64,7 @@ jobs:
     - name: Release New Version
       uses: ncipollo/release-action@v1
       with:
-        bodyFile: "changelog.md"
+        bodyFile: "output.md"
         token: ${{ secrets.PAT_TOKEN }}
         tag: ${{ steps.tag_version.outputs.new_tag }}
         name: ${{ steps.tag_version.outputs.new_tag }}

--- a/bot/cogs/__init__.py
+++ b/bot/cogs/__init__.py
@@ -1,6 +1,8 @@
 from pkgutil import iter_modules
 from typing import Literal, NamedTuple
 
+__version__ = "0.12.0-beta"
+
 
 class VersionInfo(NamedTuple):
     major: int

--- a/changes/573.misc.md
+++ b/changes/573.misc.md
@@ -1,0 +1,1 @@
+Use custom `no767/get-releasenote` action instead of `changelog.md` for obtaining release notes


### PR DESCRIPTION
# Summary

As the title states.

## Types of changes

What types of changes does your code introduce to Kumiko?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] I have generated news fragments for this PR. (if appropriate, format is {#PR}.type.md)
- [x] This PR does **not** address a duplicate issue or PR
